### PR TITLE
Add Spring Boot Starter for Easy Rules

### DIFF
--- a/easyrules-spring-boot-starter/pom.xml
+++ b/easyrules-spring-boot-starter/pom.xml
@@ -1,4 +1,7 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -7,11 +10,11 @@
         <version>2.4.1-SNAPSHOT</version>
     </parent>
 
-    <artifactId>easyrules-spring</artifactId>
+    <artifactId>easyrules-spring-boot-starter</artifactId>
     <packaging>jar</packaging>
 
-    <name>Easy Rules Spring module</name>
-    <description>Module providing support for engine configuration using Spring</description>
+    <name>Easy Rules Spring Boot Starter module</name>
+    <description>Module providing Spring Boot autoconfiguration</description>
 
     <scm>
         <url>git@github.com:EasyRules/easyrules.git</url>
@@ -32,12 +35,11 @@
 
     <developers>
         <developer>
-            <id>benas</id>
-            <name>Mahmoud Ben Hassine</name>
-            <url>http://benas.github.io</url>
-            <email>mahmoud.benhassine@icloud.com</email>
+            <id>andersonkyle</id>
+            <name>Kyle Anderson</name>
+            <url>https://github.com/andersonkyle</url>
             <roles>
-                <role>Lead developer</role>
+                <role>Contributor</role>
             </roles>
         </developer>
     </developers>
@@ -55,12 +57,17 @@
             <artifactId>easyrules-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-beans</artifactId>
+            <groupId>org.easyrules</groupId>
+            <artifactId>easyrules-spring</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-context</artifactId>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-autoconfigure</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-test</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
@@ -68,13 +75,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.assertj</groupId>
-            <artifactId>assertj-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/easyrules-spring-boot-starter/src/main/java/org/easyrules/spring/boot/autoconfigure/EasyRulesAutoConfiguration.java
+++ b/easyrules-spring-boot-starter/src/main/java/org/easyrules/spring/boot/autoconfigure/EasyRulesAutoConfiguration.java
@@ -1,0 +1,60 @@
+/**
+ * The MIT License
+ *
+ *  Copyright (c) 2017, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
+package org.easyrules.spring.boot.autoconfigure;
+
+import org.easyrules.annotation.Rule;
+import org.easyrules.api.RulesEngine;
+import org.easyrules.spring.RulesEngineFactoryBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * AutoConfiguration for {@link RulesEngine}
+ *
+ * @author Kyle Anderson
+ */
+@Configuration
+@ConditionalOnClass(RulesEngineFactoryBean.class)
+@ConditionalOnMissingBean(RulesEngineFactoryBean.class)
+public class EasyRulesAutoConfiguration {
+
+    @Bean
+    public RulesEngineFactoryBean rulesEngineFactoryBean(ApplicationContext context) {
+        List<Object> rulesFromRuleAnnotation = new ArrayList<>(context.getBeansWithAnnotation(Rule.class).values());
+        List<org.easyrules.api.Rule> rulesFromRuleImplementation = new ArrayList<>(context.getBeansOfType(org.easyrules.api.Rule.class).values());
+        List<Object> rules = new ArrayList<>();
+        rules.addAll(rulesFromRuleAnnotation);
+        rules.addAll(rulesFromRuleImplementation);
+        RulesEngineFactoryBean rulesEngineFactoryBean = new RulesEngineFactoryBean();
+        rulesEngineFactoryBean.setRules(rules);
+        return rulesEngineFactoryBean;
+    }
+
+}

--- a/easyrules-spring-boot-starter/src/main/resources/META-INF/spring.factories
+++ b/easyrules-spring-boot-starter/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=org.easyrules.spring.boot.autoconfigure.EasyRulesAutoConfiguration

--- a/easyrules-spring-boot-starter/src/test/java/org/easyrules/spring/boot/autoconfigure/EasyRulesAutoConfigurationTest.java
+++ b/easyrules-spring-boot-starter/src/test/java/org/easyrules/spring/boot/autoconfigure/EasyRulesAutoConfigurationTest.java
@@ -1,0 +1,161 @@
+/**
+ * The MIT License
+ *
+ *  Copyright (c) 2017, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
+package org.easyrules.spring.boot.autoconfigure;
+
+import org.easyrules.annotation.Action;
+import org.easyrules.annotation.Condition;
+import org.easyrules.annotation.Rule;
+import org.easyrules.api.RulesEngine;
+import org.easyrules.core.BasicRule;
+import org.easyrules.spring.RulesEngineFactoryBean;
+import org.easyrules.spring.SpringRule;
+import org.junit.After;
+import org.junit.Test;
+import org.springframework.boot.test.util.EnvironmentTestUtils;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.stereotype.Component;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * Tests for {@link EasyRulesAutoConfiguration}
+ *
+ * @author Kyle Anderson
+ */
+public class EasyRulesAutoConfigurationTest {
+
+    private AnnotationConfigApplicationContext context;
+
+    @After
+    public void tearDown() {
+        if(this.context != null) {
+            this.context.close();
+        }
+    }
+
+    @Test
+    public void rulesEngineFactoryBeanTest() {
+        load(EmptyConfiguration.class);
+        RulesEngineFactoryBean rulesEngineFactoryBean = this.context.getBean(RulesEngineFactoryBean.class);
+        assertNotNull(rulesEngineFactoryBean);
+    }
+
+    @Test
+    public void rulesEngineBeanTest() {
+        load(EmptyConfiguration.class);
+        RulesEngine rulesEngine = this.context.getBean(RulesEngine.class);
+        assertNotNull(rulesEngine);
+    }
+
+    @Test
+    public void noRulesConfigured() {
+        load(EmptyConfiguration.class);
+        RulesEngine rulesEngine = this.context.getBean(RulesEngine.class);
+        assertEquals(0, rulesEngine.getRules().size());
+    }
+
+    @Test
+    public void ruleImplementationBeanTest() {
+        load(RuleImplementationBeanConfiguration.class);
+        RulesEngine rulesEngine = this.context.getBean(RulesEngine.class);
+        assertEquals(1, rulesEngine.getRules().size());
+    }
+
+    @Test
+    public void ruleComponentAnnotationTest() {
+        load(RuleComponentAnnotationConfiguration.class);
+        RulesEngine rulesEngine = this.context.getBean(RulesEngine.class);
+        assertEquals(1, rulesEngine.getRules().size());
+    }
+
+    @Test
+    public void springRuleAnnotationTest() {
+        load(SpringRuleAnnotationConfiguration.class);
+        RulesEngine rulesEngine = this.context.getBean(RulesEngine.class);
+        assertEquals(1, rulesEngine.getRules().size());
+    }
+
+    @Configuration
+    static class EmptyConfiguration {}
+
+    @Configuration
+    static class RuleImplementationBeanConfiguration {
+        @Bean
+        public RuleImplementationBean ruleImplementationBean() {
+            return new RuleImplementationBean();
+        }
+
+        static class RuleImplementationBean extends BasicRule {
+            @Override
+            public boolean evaluate() {
+                return true;
+            }
+
+            @Override
+            public void execute() throws Exception {}
+        }
+
+    }
+
+    @Configuration
+    static class RuleComponentAnnotationConfiguration {
+        @Component
+        @Rule
+        static class RuleComponentAnnotation {
+            @Condition
+            public boolean when() {
+                return true;
+            }
+
+            @Action
+            public void then() {}
+        }
+    }
+
+    @Configuration
+    static class SpringRuleAnnotationConfiguration {
+        @SpringRule
+        static class SpringRuleAnnotation {
+            @Condition
+            public boolean when() {
+                return true;
+            }
+
+            @Action
+            public void then() {}
+        }
+    }
+
+    private void load(Class<?> config, String... environment) {
+        AnnotationConfigApplicationContext applicationContext = new AnnotationConfigApplicationContext();
+        EnvironmentTestUtils.addEnvironment(applicationContext, environment);
+        applicationContext.register(config);
+        applicationContext.register(EasyRulesAutoConfiguration.class);
+        applicationContext.refresh();
+        this.context = applicationContext;
+    }
+}

--- a/easyrules-spring-boot-starter/src/test/java/org/easyrules/spring/boot/autoconfigure/EasyRulesAutoConfigurationTest.java
+++ b/easyrules-spring-boot-starter/src/test/java/org/easyrules/spring/boot/autoconfigure/EasyRulesAutoConfigurationTest.java
@@ -36,6 +36,7 @@ import org.springframework.boot.test.util.EnvironmentTestUtils;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 import org.springframework.stereotype.Component;
 
 import static org.junit.Assert.assertEquals;
@@ -99,6 +100,13 @@ public class EasyRulesAutoConfigurationTest {
         assertEquals(1, rulesEngine.getRules().size());
     }
 
+    @Test
+    public void multipleRulesTest() {
+        load(MultipleRulesConfiguration.class);
+        RulesEngine rulesEngine = this.context.getBean(RulesEngine.class);
+        assertEquals(3, rulesEngine.getRules().size());
+    }
+
     @Configuration
     static class EmptyConfiguration {}
 
@@ -149,6 +157,10 @@ public class EasyRulesAutoConfigurationTest {
             public void then() {}
         }
     }
+
+    @Configuration
+    @Import({RuleImplementationBeanConfiguration.class, RuleComponentAnnotationConfiguration.class, SpringRuleAnnotationConfiguration.class})
+    static class MultipleRulesConfiguration {}
 
     private void load(Class<?> config, String... environment) {
         AnnotationConfigApplicationContext applicationContext = new AnnotationConfigApplicationContext();

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
         <module>easyrules-core</module>
         <module>easyrules-quartz</module>
         <module>easyrules-spring</module>
+        <module>easyrules-spring-boot-starter</module>
     </modules>
 
     <packaging>pom</packaging>
@@ -32,7 +33,7 @@
         <assertj.version>2.6.0</assertj.version>
         <mockito.version>2.7.1</mockito.version>
         <quartz.version>2.2.3</quartz.version>
-        <spring.version>4.3.6.RELEASE</spring.version>
+        <spring-io-platform.version>Brussels-SR1</spring-io-platform.version>
         <maven-cobertura-plugin.version>2.7</maven-cobertura-plugin.version>
         <maven-coveralls-plugin.version>4.3.0</maven-coveralls-plugin.version>
         <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
@@ -99,6 +100,12 @@
             </dependency>
 
             <dependency>
+                <groupId>org.easyrules</groupId>
+                <artifactId>easyrules-spring-boot-starter</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
                 <version>${junit.version}</version>
@@ -117,6 +124,14 @@
                 <artifactId>mockito-core</artifactId>
                 <version>${mockito.version}</version>
                 <scope>test</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>io.spring.platform</groupId>
+                <artifactId>platform-bom</artifactId>
+                <version>${spring-io-platform.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -209,6 +224,24 @@
                         <goals>
                             <goal>format</goal>
                         </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>enforce-dependency-convergence</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <dependencyConvergence/>
+                            </rules>
+                            <fail>true</fail>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
A Spring Boot Starter for Easy Rules to make it even _easier_ to get up and running for Spring Boot projects.